### PR TITLE
fix: 회사 로고 이미지 URL 수정

### DIFF
--- a/src/components/jobRate/JobCurrentSituation.tsx
+++ b/src/components/jobRate/JobCurrentSituation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEmploymentStats } from "@/apis/applications";
+const BASE_URL = process.env.NEXT_PUBLIC_IMAGE_URL;
 import useGetClass from "@/util/getClassName";
 
 export default function JobCurrentSituation() {
@@ -27,7 +28,7 @@ export default function JobCurrentSituation() {
                   className="bg-[#fff] border border-[#F7F7F7] rounded-md w-[100px] h-[44px] p-1"
                 >
                   <img
-                    src={data.logo_url}
+                    src={`${BASE_URL}/${data.logo_url}`}
                     alt={`${data.company_name} 로고`}
                     className="w-full h-auto rounded-md"
                   />


### PR DESCRIPTION
회사 로고 이미지 URL 앞에 BASE_URL을 추가하여 이미지를 정상적으로 불러오도록 수정

- 기존에는 로고 이미지 URL이 절대 경로가 아니어서 이미지를 불러오지 못함
- BASE_URL을 추가하여 이미지 URL을 절대 경로로 변경
- 이제 회사 로고 이미지가 정상적으로 표시됨

## 특이사항
- 

## 관련 이슈

- resolved #105 
